### PR TITLE
MO: Merchant invoice

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <module>
-	<name>ps_emailalerts</name>
-	<displayName><![CDATA[Mail alerts]]></displayName>
-	<version><![CDATA[2.0.1]]></version>
-	<description><![CDATA[Sends e-mail notifications to customers and merchants regarding stock and order modifications.]]></description>
-	<author><![CDATA[PrestaShop]]></author>
-	<tab><![CDATA[administration]]></tab>
-	<confirmUninstall>Are you sure you want to delete all customer notifications?</confirmUninstall>
-	<is_configurable>1</is_configurable>
-	<need_instance>0</need_instance>
+    <name>ps_emailalerts</name>
+    <displayName><![CDATA[Mail alerts]]></displayName>
+    <version><![CDATA[2.0.1]]></version>
+    <description><![CDATA[Sends e-mail notifications to customers and merchants regarding stock and order modifications.]]></description>
+    <author><![CDATA[PrestaShop]]></author>
+    <tab><![CDATA[administration]]></tab>
+    <is_configurable>1</is_configurable>
+    <need_instance>0</need_instance>
 	<limited_countries></limited_countries>
 </module>

--- a/mails/en/invoice.html
+++ b/mails/en/invoice.html
@@ -70,14 +70,14 @@
 <tr>
 	<td align="center" class="titleblock" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
-			<span class="title" style="font-weight:500;font-size:28px;text-transform:uppercase;line-height:33px">Order Completed!</span>
+			<span class="title" style="font-weight:500;font-size:28px;text-transform:uppercase;line-height:33px">Order paid!</span>
 		</font>
 	</td>
 </tr>
 <tr>
 	<td class="linkbelow" style="padding:7px 0">
 		<font size="2" face="Open-sans, sans-serif" color="#555454">
-			<span>The order placed on {shop_name} by the following customer: {firstname} {lastname} ({email}) was completed. See the attached invoice.</span>
+			<span>The order placed on {shop_name} by the following customer: {firstname} {lastname} ({email}) was completed. <br />See the attached invoice.</span>
 		</font>
 	</td>
 </tr>

--- a/mails/en/invoice.html
+++ b/mails/en/invoice.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/1999/REC-html401-19991224/strict.dtd">
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
+		<title>Message from {shop_name}</title>
+		
+		
+		<style>	@media only screen and (max-width: 300px){ 
+				body {
+					width:218px !important;
+					margin:auto !important;
+				}
+				.table {width:195px !important;margin:auto !important;}
+				.logo, .titleblock, .linkbelow, .box, .footer, .space_footer{width:auto !important;display: block !important;}		
+				span.title{font-size:20px !important;line-height: 23px !important}
+				span.subtitle{font-size: 14px !important;line-height: 18px !important;padding-top:10px !important;display:block !important;}		
+				td.box p{font-size: 12px !important;font-weight: bold !important;}
+				.table-recap table, .table-recap thead, .table-recap tbody, .table-recap th, .table-recap td, .table-recap tr { 
+					display: block !important; 
+				}
+				.table-recap{width: 200px!important;}
+				.table-recap tr td, .conf_body td{text-align:center !important;}	
+				.address{display: block !important;margin-bottom: 10px !important;}
+				.space_address{display: none !important;}	
+			}
+	@media only screen and (min-width: 301px) and (max-width: 500px) { 
+				body {width:308px!important;margin:auto!important;}
+				.table {width:285px!important;margin:auto!important;}	
+				.logo, .titleblock, .linkbelow, .box, .footer, .space_footer{width:auto!important;display: block!important;}	
+				.table-recap table, .table-recap thead, .table-recap tbody, .table-recap th, .table-recap td, .table-recap tr { 
+					display: block !important; 
+				}
+				.table-recap{width: 295px !important;}
+				.table-recap tr td, .conf_body td{text-align:center !important;}
+				
+			}
+	@media only screen and (min-width: 501px) and (max-width: 768px) {
+				body {width:478px!important;margin:auto!important;}
+				.table {width:450px!important;margin:auto!important;}	
+				.logo, .titleblock, .linkbelow, .box, .footer, .space_footer{width:auto!important;display: block!important;}			
+			}
+	@media only screen and (max-device-width: 480px) { 
+				body {width:308px!important;margin:auto!important;}
+				.table {width:285px;margin:auto!important;}	
+				.logo, .titleblock, .linkbelow, .box, .footer, .space_footer{width:auto!important;display: block!important;}
+				
+				.table-recap{width: 295px!important;}
+				.table-recap tr td, .conf_body td{text-align:center!important;}	
+				.address{display: block !important;margin-bottom: 10px !important;}
+				.space_address{display: none !important;}	
+			}
+</style>
+
+	</head>
+	<body style="-webkit-text-size-adjust:none;background-color:#fff;width:650px;font-family:Open-sans, sans-serif;color:#555454;font-size:13px;line-height:18px;margin:auto" >
+		<table class="table table-mail" style="width:100%;margin-top:10px;-moz-box-shadow:0 0 5px #afafaf;-webkit-box-shadow:0 0 5px #afafaf;-o-box-shadow:0 0 5px #afafaf;box-shadow:0 0 5px #afafaf;filter:progid:DXImageTransform.Microsoft.Shadow(color=#afafaf,Direction=134,Strength=5)">
+			<tr>
+				<td class="space" style="width:20px;padding:7px 0">&nbsp;</td>
+				<td align="center" style="padding:7px 0">
+					<table class="table" bgcolor="#ffffff" style="width:100%">
+						<tr>
+							<td align="center" class="logo" style="border-bottom:4px solid #333333;padding:7px 0">
+								<a title="{shop_name}" href="{shop_url}" style="color:#337ff1">
+									<img src="{shop_logo}" alt="{shop_name}" />
+								</a>
+							</td>
+						</tr>
+
+<tr>
+	<td align="center" class="titleblock" style="padding:7px 0">
+		<font size="2" face="Open-sans, sans-serif" color="#555454">
+			<span class="title" style="font-weight:500;font-size:28px;text-transform:uppercase;line-height:33px">Order Completed!</span>
+		</font>
+	</td>
+</tr>
+<tr>
+	<td class="linkbelow" style="padding:7px 0">
+		<font size="2" face="Open-sans, sans-serif" color="#555454">
+			<span>The order placed on {shop_name} by the following customer: {firstname} {lastname} ({email}) was completed. See the attached invoice.</span>
+		</font>
+	</td>
+</tr>
+<tr>
+	<td class="space_footer" style="padding:0!important">&nbsp;</td>
+</tr>
+<tr>
+	<td class="box" colspan="3" style="border:1px solid #D6D4D4;background-color:#f8f8f8;padding:7px 0">
+		<table class="table" style="width:100%">
+			<tr>
+				<td width="10" style="padding:7px 0">&nbsp;</td>
+				<td style="padding:7px 0">
+					<font size="2" face="Open-sans, sans-serif" color="#555454">
+						<p data-html-only="1" style="border-bottom:1px solid #D6D4D4;margin:3px 0 7px;text-transform:uppercase;font-weight:500;font-size:18px;padding-bottom:10px">
+							Customer message:						</p>
+						<span style="color:#777">
+							{message}
+						</span>
+					</font>
+				</td>
+				<td width="10" style="padding:7px 0">&nbsp;</td>
+			</tr>
+		</table>
+	</td>
+</tr>
+
+						<tr>
+							<td class="space_footer" style="padding:0!important">&nbsp;</td>
+						</tr>
+						<tr>
+							<td class="footer" style="border-top:4px solid #333333;padding:7px 0">
+								<span><a href="{shop_url}" style="color:#337ff1">{shop_name}</a> powered by <a href="http://www.prestashop.com/" style="color:#337ff1">PrestaShop&trade;</a></span>
+							</td>
+						</tr>
+					</table>
+				</td>
+				<td class="space" style="width:20px;padding:7px 0">&nbsp;</td>
+			</tr>
+		</table>
+	</body>
+</html>

--- a/mails/en/invoice.txt
+++ b/mails/en/invoice.txt
@@ -1,0 +1,13 @@
+
+[{shop_url}] 
+
+Order Completed! 
+
+The order placed on {shop_name} by the following customer: {firstname} {lastname} ({email}) was completed. See the attached invoice.
+
+
+{message} 
+
+{shop_name} [{shop_url}] powered by
+PrestaShop(tm) [http://www.prestashop.com/] 
+

--- a/mails/en/invoice.txt
+++ b/mails/en/invoice.txt
@@ -1,7 +1,7 @@
 
 [{shop_url}] 
 
-Order Completed! 
+Order paid! 
 
 The order placed on {shop_name} by the following customer: {firstname} {lastname} ({email}) was completed. See the attached invoice.
 

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -306,7 +306,7 @@ class Ps_EmailAlerts extends Module
         if ((int)Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
             $order_invoice_list = $order->getInvoicesCollection();
             Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => $order_invoice_list));
-            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, new Context()->smarty);
+            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
             $file_attachement['content'] = $pdf->render(false);
             $file_attachement['name'] = Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $order->id_shop).sprintf('%06d', $order->invoice_number).'.pdf';
             $file_attachement['mime'] = 'application/pdf';

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -264,7 +264,8 @@ class Ps_EmailAlerts extends Module
         }
         // Getting differents vars
         $context = Context::getContext();
-        $id_lang = (int) $context->language->id;
+        
+        $id_lang = (int) Configuration::get('PS_LANG_DEFAULT');
         $id_shop = (int) $context->shop->id;
         
         $id_order = $params['id_order'];

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -1088,7 +1088,7 @@ class Ps_EmailAlerts extends Module
             array(
                 'type' => 'switch',
                 'is_bool' => true, //retro compat 1.5
-                'label' => $this->trans('Send Invoice', array(), 'Modules.Mailalerts.Admin'),
+                'label' => $this->trans('Invoice', array(), 'Modules.Mailalerts.Admin'),
                 'name' => 'MA_MERCHANT_INVOICE',
                 'desc' => $this->trans('Send an invoice when the order is paid.', array(), 'Modules.Mailalerts.Admin'),
                 'values' => array(

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -303,8 +303,6 @@ class Ps_EmailAlerts extends Module
         $iso = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
         
         // Join PDF invoice
-        $language = new Language(1);
-        $this->context->language = $language;
         if ((int)Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
             $order_invoice_list = $order->getInvoicesCollection();
             Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => $order_invoice_list));

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -308,7 +308,7 @@ class Ps_EmailAlerts extends Module
             Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => $order_invoice_list));
             $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
             $file_attachement['content'] = $pdf->render(false);
-            $file_attachement['name'] = Configuration::get('PS_INVOICE_PREFIX', (int)$order->id_lang, null, $order->id_shop).sprintf('%06d', $order->invoice_number).'.pdf';
+            $file_attachement['name'] = Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $order->id_shop).sprintf('%06d', $order->invoice_number).'.pdf';
             $file_attachement['mime'] = 'application/pdf';
             
         } else {

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -92,7 +92,7 @@ class Ps_EmailAlerts extends Module
             !$this->registerHook('displayCustomerAccount') ||
             !$this->registerHook('displayMyAccountBlock') ||
             !$this->registerHook('actionProductDelete') ||
-            !$this->registerHook('actionPaymentConfirmation') ||
+            !$this->registerHook('actionOrderStatusPostUpdate') ||
             !$this->registerHook('actionProductAttributeDelete') ||
             !$this->registerHook('actionProductAttributeUpdate') ||
             !$this->registerHook('actionProductCoverage') ||
@@ -327,7 +327,7 @@ class Ps_EmailAlerts extends Module
         // Send 1 email by merchant mail, because Mail::Send doesn't work with an array of recipients
         $merchant_mails = explode(self::__MA_MAIL_DELIMITOR__, $this->merchant_mails);
         
-        if ($order_status->paid) {
+        if ($order_status->pdf_invoice) {
         
             foreach ($merchant_mails as $merchant_mail) {
                 // Default language

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -303,6 +303,8 @@ class Ps_EmailAlerts extends Module
         $iso = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
         
         // Join PDF invoice
+        $language = new Language($id_lang);
+        $this->context->language = $language;
         if ((int)Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
             $order_invoice_list = $order->getInvoicesCollection();
             Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => $order_invoice_list));

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -303,11 +303,10 @@ class Ps_EmailAlerts extends Module
         $iso = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
         
         // Join PDF invoice
-        $cleanContext = new Context();
         if ((int)Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
             $order_invoice_list = $order->getInvoicesCollection();
             Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => $order_invoice_list));
-            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $cleanContext);
+            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, new Context()->smarty);
             $file_attachement['content'] = $pdf->render(false);
             $file_attachement['name'] = Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $order->id_shop).sprintf('%06d', $order->invoice_number).'.pdf';
             $file_attachement['mime'] = 'application/pdf';

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -303,7 +303,7 @@ class Ps_EmailAlerts extends Module
         $iso = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
         
         // Join PDF invoice
-        $language = new Language($id_lang);
+        $language = new Language(1);
         $this->context->language = $language;
         if ((int)Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
             $order_invoice_list = $order->getInvoicesCollection();

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -303,10 +303,11 @@ class Ps_EmailAlerts extends Module
         $iso = Language::getIsoById((int) Configuration::get('PS_LANG_DEFAULT'));
         
         // Join PDF invoice
+        $cleanContext = new Context();
         if ((int)Configuration::get('PS_INVOICE') && $order_status->invoice && $order->invoice_number) {
             $order_invoice_list = $order->getInvoicesCollection();
             Hook::exec('actionPDFInvoiceRender', array('order_invoice_list' => $order_invoice_list));
-            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $this->context->smarty);
+            $pdf = new PDF($order_invoice_list, PDF::TEMPLATE_INVOICE, $cleanContext);
             $file_attachement['content'] = $pdf->render(false);
             $file_attachement['name'] = Configuration::get('PS_INVOICE_PREFIX', $id_lang, null, $order->id_shop).sprintf('%06d', $order->invoice_number).'.pdf';
             $file_attachement['mime'] = 'application/pdf';


### PR DESCRIPTION
In many circumstances our customers asked us to receive, as merchant, the invoice related to an order.
This is often used when the notification email is received by the stock manager that print the invoice and attach it to the physical goods.
I added the possibility to ask for invoice sending in module configuration.

The email is notified on order status change. Thus it respects the order workflow, even if you change the status in the order history.

Cheers!