### PR TITLE
Fix total tax when using discounts

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -409,7 +409,7 @@ class Ps_EmailAlerts extends Module
             '{total_discounts}' => Tools::displayPrice($order->total_discounts, $currency),
             '{total_shipping}' => Tools::displayPrice($order->total_shipping, $currency),
             '{total_tax_paid}' => Tools::displayPrice(
-                ($order->total_products_wt - $order->total_products) + ($order->total_shipping_tax_incl - $order->total_shipping_tax_excl),
+                $order->total_paid_tax_incl - $order->total_paid_tax_excl,
                 $currency,
                 false
             ),


### PR DESCRIPTION
This module has the same issue as in PaymentModule.php, total tax is wrong. Described here - https://github.com/PrestaShop/PrestaShop/issues/16227

This PR fixes it.