### PR TITLE
Check product minimal quantity

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -602,8 +602,7 @@ class Ps_EmailAlerts extends Module
             if ($this->customer_qty && $result['quantity'] >= $result['minimal_quantity']) {
                 MailAlert::sendCustomerAlert((int) $result['id_product'], (int) $params['id_product_attribute']);
             }
-        }
-        else{
+        } else {
             if ($this->customer_qty && $quantity >= $minimal_quantity) {
                     MailAlert::sendCustomerAlert((int) $product->id, (int) $params['id_product_attribute']);
                 }

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -590,7 +590,7 @@ class Ps_EmailAlerts extends Module
             }
         }
 
-        if($product_has_attributes) {
+        if ($product_has_attributes) {
             $sql = '
 			SELECT sa.id_product, sa.quantity, pa.minimal_quantity, sa.id_product_attribute
             		FROM '._DB_PREFIX_.'stock_available sa join '._DB_PREFIX_.'product_attribute pa


### PR DESCRIPTION
The module doesn't check minimal quantity of product or product attributes when sends an email to suscribed customers. 
This fix modifies this and now checks the minimal quantity instead of just checking if the quantity is greater than 0.