### PR TITLE
Wrong condition result broke module installation

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -172,7 +172,7 @@ class Ps_EmailAlerts extends Module
     public function uninstallPrestaShop16Module()
     {
         if (!Module::isInstalled(self::PS_16_EQUIVALENT_MODULE)) {
-            return false;
+            return true;
         }
         $oldModule = Module::getInstanceByName(self::PS_16_EQUIVALENT_MODULE);
         if ($oldModule) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | more details in Issue, but as you can see condition result is wrong, if you don't have 1.6 module you are all set and you can proceed with installation...
| Type?         | critical
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#19842.
| How to test?  | try to install module on clean installation, before and after
| Sponsor company  | impSolutions

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
