### PR TITLE
Fixed configuration initialization at install

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -172,7 +172,7 @@ class Ps_EmailAlerts extends Module
     public function uninstallPrestaShop16Module()
     {
         if (!Module::isInstalled(self::PS_16_EQUIVALENT_MODULE)) {
-            return false;
+            return true;
         }
         $oldModule = Module::getInstanceByName(self::PS_16_EQUIVALENT_MODULE);
         if ($oldModule) {


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixed configuration initialization at install
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#19842
| How to test?  | * Install module (without having module `mailalerts` installed)<br>* Configuration is initialized

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
