### PR TITLE
[WIP] Refactor install logic

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -185,7 +185,7 @@ class Ps_EmailAlerts extends Module
                 return parent::uninstall();
             };
             $parentUninstallClosure = $parentUninstallClosure->bindTo($oldModule, get_class($oldModule));
-            $parentUninstallClosure();
+            return $parentUninstallClosure();
         }
         return true;
     }

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -115,7 +115,13 @@ class Ps_EmailAlerts extends Module
             return false;
         }
 
-        if ($delete_params && $this->uninstallPrestaShop16Module()) {
+        // handle PS16
+        $moduleInstalledOn16 = (Module::isInstalled(self::PS_16_EQUIVALENT_MODULE));
+        if ($moduleInstalledOn16 && (!$this->uninstallPrestaShop16Module())) {
+            return false;
+        }
+
+        if ($delete_params) {
             Configuration::updateValue('MA_MERCHANT_ORDER', 1);
             Configuration::updateValue('MA_MERCHANT_OOS', 1);
             Configuration::updateValue('MA_CUSTOMER_QTY', 1);
@@ -171,9 +177,6 @@ class Ps_EmailAlerts extends Module
      */
     public function uninstallPrestaShop16Module()
     {
-        if (!Module::isInstalled(self::PS_16_EQUIVALENT_MODULE)) {
-            return true;
-        }
         $oldModule = Module::getInstanceByName(self::PS_16_EQUIVALENT_MODULE);
         if ($oldModule) {
             // This closure calls the parent class to prevent data to be erased


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | See below
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20478
| How to test?  | Please confirm issue is solved. You need to check that module works correctly in 3 usecases (see below). This PR **only modifies install logic** so there should be no side-effects for the module behavior.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

## Description

There was an issue in the install logic.
The SQL table for this module was created if `$this->uninstallPrestaShop16Module()` returned `true`.
However
1. `$this->uninstallPrestaShop16Module()` returns false if module for PS 1.6 was not installed
2. `$this->uninstallPrestaShop16Module()` returns false if module for PS 1.6 was installed but failed to be uninstalled
3. `$this->uninstallPrestaShop16Module()` returns true if module for PS 1.6 was installed and was successfully installed

Issue https://github.com/PrestaShop/PrestaShop/issues/20478 happens because we are in usecase 1. So ... no SQL table in usecase 1 although install process finishes successfull 😱 

My PR fixes this logic.

## How to test - 3 usecases

1. Module is installed on PS 1.7
2. Module is upgraded on PS 1.7 (v2.1.0 => dev)
3. the equivalent module for PS 1.6 was installed and new module version is installed