### PR TITLE
Fix cast error when removing an Alert

### DIFF
--- a/controllers/front/actions.php
+++ b/controllers/front/actions.php
@@ -70,7 +70,7 @@ class Ps_EmailAlertsActionsModuleFrontController extends ModuleFrontController
         $context = Context::getContext();
         if (MailAlert::deleteAlert(
             (int) $context->customer->id,
-            (int) $context->customer->email,
+            (string) $context->customer->email,
             (int) $product->id,
             (int) $this->id_product_attribute,
             (int) $context->shop->id


### PR DESCRIPTION
The email is casted as an int, so the query to remove the alert doesnt work properly when the user made an alert and later creates an account.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | An email variable is casted as int when you try to remove an alert. It causes the alert not being removed if you did the alert as a Guest and then you try to remove it when you log in.
| Type?         | Bug fix
| BC breaks?    | Yes
| Deprecations? | No
| Fixed ticket? | No
| How to test?  |  Create an alert as a guest. Then create an account with the same email, and try to remove the alert.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
