### PR TITLE
Stops install if module PS16 cannot be uninstalled

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -182,7 +182,7 @@ class Ps_EmailAlerts extends Module
                 return parent::uninstall();
             };
             $parentUninstallClosure = $parentUninstallClosure->bindTo($oldModule, get_class($oldModule));
-            $parentUninstallClosure();
+            return $parentUninstallClosure();
         }
         return true;
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Modifies install logic, to make sure that if module for PS16 is installed AND it fails to be uninstalled, then the install process fails too.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | You need to check that module works correctly in 4 usecases (see below). This PR **only modifies install logic** so there should be no side-effects for the module behavior.

## How to test - 4 usecases

1. Module is installed on PS 1.7 => should work
2. Module is upgraded on PS 1.7 => should work
3. the equivalent module for PS 1.6 was installed and new module version install is launched => new module should be installed, old PS16 module should be uninstalled
4. the equivalent module for PS 1.6 was installed and new module version install is launched, but PS16 module CANNOT be uninstalled (see below) then install should fail

Basically 4 is a edge-case scenario that should not happen in most environments, however we must make sure our code is robust and fault-tolerant.

#### How to make sure PS16 module cannot be installed ?

1. install it
2. modify main php file of module
3. find line with `public function uninstall($delete_params = true)`
4. modify it to obtain:
```
public function uninstall($delete_params = true)
{
    return false;
}
```
