### PR TITLE
Fix product name missing

### DIFF
--- a/MailAlert.php
+++ b/MailAlert.php
@@ -180,7 +180,7 @@ class MailAlert extends ObjectModel
             $context->language->id = $id_lang;
 
             $product = new Product((int) $id_product, false, $id_lang, $id_shop);
-            $product_name = Product::getProductName($product->id, $id_product_attribute, $id_lang);
+            $product_name = $product->name;
             $product_link = $link->getProductLink($product, $product->link_rewrite, null, null, $id_lang, $id_shop, $id_product_attribute);
             $template_vars = array(
                 '{product}' => $product_name,


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Don't know if you have noticed guys but the name was missing for me, patching this line fixes it.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/22628
| How to test?  | Create a product, set the availability to 0. Register for notification with a user account. Set the availability back to 1 (or anything else). Wait for the email, the name will be empty.
| Screenshot | ![Issue](https://user-images.githubusercontent.com/7504132/103413152-9d2c0a80-4b78-11eb-8054-80122d65459e.png)