### PR TITLE
Bump version to 2.2.2

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_emailalerts</name>
 	<displayName><![CDATA[Mail alerts]]></displayName>
-	<version><![CDATA[2.2.1]]></version>
+	<version><![CDATA[2.2.2]]></version>
 	<description><![CDATA[Sends e-mail notifications to customers and merchants regarding stock and order modifications.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[administration]]></tab>

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -59,7 +59,7 @@ class Ps_EmailAlerts extends Module
     {
         $this->name = 'ps_emailalerts';
         $this->tab = 'administration';
-        $this->version = '2.2.1';
+        $this->version = '2.2.2';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | As per discussion on slack bumping the version to 2.2.2
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | nope.
| How to test?  | upgrade the module.

The milestone here lists everything that was done for 2.2.2: https://github.com/PrestaShop/ps_emailalerts/milestone/1?closed=1 

PM should also create 2.2.3 milestone and consider assigning the currently open issues / pr:s to milestones so that there is clear path forward.