### PR TITLE
Fix sending out of stock alerts for products being deleted

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -571,6 +571,7 @@ class Ps_EmailAlerts extends Module
         $check_oos = ($product_has_attributes && $id_product_attribute) || (!$product_has_attributes && !$id_product_attribute);
 
         if ($check_oos &&
+	    Validate::isLoadedObject($product) &&
             $product->active == 1 &&
             (int) $quantity <= $ma_last_qties &&
             !(!$this->merchant_oos || empty($this->merchant_mails)) &&

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -571,7 +571,7 @@ class Ps_EmailAlerts extends Module
         $check_oos = ($product_has_attributes && $id_product_attribute) || (!$product_has_attributes && !$id_product_attribute);
 
         if ($check_oos &&
-	    Validate::isLoadedObject($product) &&
+        Validate::isLoadedObject($product) &&
             $product->active == 1 &&
             (int) $quantity <= $ma_last_qties &&
             !(!$this->merchant_oos || empty($this->merchant_mails)) &&

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -551,11 +551,11 @@ class Ps_EmailAlerts extends Module
         $id_product = (int) $params['id_product'];
         $id_product_attribute = (int) $params['id_product_attribute'];
 
-	$context = Context::getContext();
+        $context = Context::getContext();
         $id_shop = (int) $context->shop->id;
         $id_lang = (int) $context->language->id;
         $locale = $context->language->getLocale();
-        $product = new Product($id_product, false, $id_lang, $id_shop, $context);    
+        $product = new Product($id_product, false, $id_lang, $id_shop, $context);
 
         /*
         * We don't want to do anything for products being deleted or inactive products.

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -557,11 +557,6 @@ class Ps_EmailAlerts extends Module
         $locale = $context->language->getLocale();
         $product = new Product($id_product, false, $id_lang, $id_shop, $context);
 
-        /*
-        * We don't want to do anything for products being deleted or inactive products.
-        * Check for active products is not sufficent, because even an empty object is active by default.
-        * Without the Validate check, it used to send nonsense emails when product was deleted.
-        */
         if (!Validate::isLoadedObject($product) || $product->active != 1) {
             return;
         }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Module used to send nonsense emails for X combinations out of stock, when you deleted a product. A simple fix to check if the product actually exist will fix it. `$product->active == 1` is not enough, because even an empty Product object has default active set to true.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#9641
| How to test?  | Install this module, enable sending out of stock emails, set treshold to 3. Create product with 2 combinations. Set  one combination quantity to 10, second combination to 1. You should receive email about low stock. Go delete the product, you should receive no email.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
