### PR TITLE
Fix #25886

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -751,11 +751,8 @@ class Ps_EmailAlerts extends Module
 
     public function hookDisplayHeader()
     {
-        $this->page_name = Dispatcher::getInstance()->getController();
-        if (in_array($this->page_name, ['product', 'account'])) {
-            $this->context->controller->addJS($this->_path . 'js/mailalerts.js');
-            $this->context->controller->addCSS($this->_path . 'css/mailalerts.css', 'all');
-        }
+        $this->context->controller->addJS($this->_path . 'js/mailalerts.js');
+        $this->context->controller->addCSS($this->_path . 'css/mailalerts.css', 'all');
     }
 
     /**


### PR DESCRIPTION
This change is needed for quick view. Without scripts loaded, customers are unable to subscribe to product availability alerts in the quick view window.

Not using quick view? In this case exceptions for the header hook may be added to not include unnecessary scripts and styles.


| Questions     | Answers
| ------------- | -------------------------------------------------------
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | #25886
| How to test?  | Have an out of stock product and try to subscribe for it by a quick view window, not on product page
