### PR TITLE
Do not send out emails if quantity did not change

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -548,11 +548,11 @@ class Ps_EmailAlerts extends Module
 
     public function hookActionUpdateQuantity($params)
     {
-	// Do not send email if stock did not change
+       // Do not send email if stock did not change
         if (isset($params['delta_quantity']) && (int) $params['delta_quantity'] == 0) {
             return;
         }
- 
+
         $id_product = (int) $params['id_product'];
         $id_product_attribute = (int) $params['id_product_attribute'];
 

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -549,7 +549,7 @@ class Ps_EmailAlerts extends Module
     public function hookActionUpdateQuantity($params)
     {
         // Do not send email if stock did not change
-        if (isset($params['delta_quantity']) && (int) $params['delta_quantity'] == 0) {
+        if (isset($params['delta_quantity']) && (int) $params['delta_quantity'] === 0) {
             return;
         }
 

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -548,7 +548,7 @@ class Ps_EmailAlerts extends Module
 
     public function hookActionUpdateQuantity($params)
     {
-       // Do not send email if stock did not change
+        // Do not send email if stock did not change
         if (isset($params['delta_quantity']) && (int) $params['delta_quantity'] == 0) {
             return;
         }

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -548,6 +548,11 @@ class Ps_EmailAlerts extends Module
 
     public function hookActionUpdateQuantity($params)
     {
+	// Do not send email if stock did not change
+        if (isset($params['delta_quantity']) && (int) $params['delta_quantity'] == 0) {
+            return;
+        }
+ 
         $id_product = (int) $params['id_product'];
         $id_product_attribute = (int) $params['id_product_attribute'];
 


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | With normal or combination products, if product or one of the combination is out-of-stock and I edit the product, everytime I save it, I'll receive an email.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#25981
| How to test?  | Install both this and related PR. Enable notifications for out of stock products in email alerts. Create a product with combinations, set quantity of all of them below the treshold. See that every time you save product, it sends you many emails. With these PRs, it's fixed.

Related PR: https://github.com/PrestaShop/PrestaShop/pull/25984
If module will be used on older PS, it will still work fine, I check if new parameter is sent. No BC break.
Ping @florine2623 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
