### PR TITLE
Move php-dev-tools to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,10 @@
     }
   ],
   "require": {
-    "php": ">=5.6",
-    "prestashop/php-dev-tools": "^3.15"
+    "php": ">=5.6"
+  },
+  "require-dev": {
+    "prestashop/php-dev-tools": "^3.16"
   },
   "config": {
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,9 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "17f755fae8e7089ab818dd449b530b76",
-    "packages": [
+    "content-hash": "6ba77c2468ea976338ae70b3d0ceed1b",
+    "packages": [],
+    "packages-dev": [
         {
             "name": "composer/semver",
             "version": "3.2.4",
@@ -554,6 +555,52 @@
             "time": "2020-10-14T08:39:05+00:00"
         },
         {
+            "name": "prestashop/autoindex",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PrestaShopCorp/autoindex.git",
+                "reference": "92e10242f94a99163dece280f6bd7b7c2b79c158"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PrestaShopCorp/autoindex/zipball/92e10242f94a99163dece280f6bd7b7c2b79c158",
+                "reference": "92e10242f94a99163dece280f6bd7b7c2b79c158",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^3.1",
+                "php": ">=5.6",
+                "symfony/console": "^3.4",
+                "symfony/finder": "^3.4"
+            },
+            "bin": [
+                "bin/autoindex"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PrestaShop\\AutoIndex\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "AFL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "PrestaShop SA",
+                    "email": "contact@prestashop.com"
+                }
+            ],
+            "description": "Automatically add an 'index.php' in all the current or specified directories and all sub-directories.",
+            "homepage": "https://github.com/PrestaShopCorp/autoindex",
+            "support": {
+                "source": "https://github.com/PrestaShopCorp/autoindex/tree/v1.0.0"
+            },
+            "time": "2020-03-11T13:37:03+00:00"
+        },
+        {
             "name": "prestashop/header-stamp",
             "version": "v1.7",
             "source": {
@@ -605,21 +652,22 @@
         },
         {
             "name": "prestashop/php-dev-tools",
-            "version": "v3.15",
+            "version": "v3.16.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PrestaShop/php-dev-tools.git",
-                "reference": "1570fd43b0f5a8cfa105e6f2211c818c902951f0"
+                "reference": "785108c29ef6f580930372d88b8f551740fdee98"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PrestaShop/php-dev-tools/zipball/1570fd43b0f5a8cfa105e6f2211c818c902951f0",
-                "reference": "1570fd43b0f5a8cfa105e6f2211c818c902951f0",
+                "url": "https://api.github.com/repos/PrestaShop/php-dev-tools/zipball/785108c29ef6f580930372d88b8f551740fdee98",
+                "reference": "785108c29ef6f580930372d88b8f551740fdee98",
                 "shasum": ""
             },
             "require": {
                 "friendsofphp/php-cs-fixer": "^2.14",
                 "php": ">=5.6.0",
+                "prestashop/autoindex": "^1.0",
                 "prestashop/header-stamp": "^1.0",
                 "squizlabs/php_codesniffer": "^3.4",
                 "symfony/console": "~3.2 || ~4.0 || ~5.0",
@@ -644,9 +692,9 @@
             "description": "PrestaShop coding standards",
             "support": {
                 "issues": "https://github.com/PrestaShop/php-dev-tools/issues",
-                "source": "https://github.com/PrestaShop/php-dev-tools/tree/v3.15"
+                "source": "https://github.com/PrestaShop/php-dev-tools/tree/v3.16.1"
             },
-            "time": "2021-03-11T15:36:18+00:00"
+            "time": "2021-10-18T07:48:21+00:00"
         },
         {
             "name": "psr/log",
@@ -1609,7 +1657,6 @@
             "time": "2020-10-24T10:57:07+00:00"
         }
     ],
-    "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
@@ -1622,5 +1669,5 @@
     "platform-overrides": {
         "php": "5.6.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | because `prestashop/php-dev-tools` was not in the `require-dev` dependencies, it was taken into account when trying to require it on PrestaShop 8.0, but the php compatibility was causing an issue. This PR solves the issue by putting `prestashop/php-dev-tools` in the `require-dev` dependencies.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#27037
| How to test?  | No test needed?

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
