### PR TITLE
Add last key of breadcrumbs

### DIFF
--- a/controllers/front/account.php
+++ b/controllers/front/account.php
@@ -40,6 +40,10 @@ class Ps_EmailAlertsAccountModuleFrontController extends ModuleFrontController
     {
         $breadcrumb = parent::getBreadcrumbLinks();
         $breadcrumb['links'][] = $this->addMyAccountToBreadcrumb();
+        $breadcrumb['links'][] = [
+            'title' => $this->trans('My alerts', [], 'Modules.Emailalerts.Shop'),
+            'url' => $this->context->link->getModuleLink('ps_emailalerts', 'account'),
+        ];
 
         return $breadcrumb;
     }


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Last key of breadcrumbs was missing on page in my account section.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  | Check the page before and after.

![breadcrumbs](https://user-images.githubusercontent.com/6097524/148143499-399c3076-b46b-4dbd-840a-f228d7d73820.JPG)

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
