### PR TITLE
Fix an issue with kernel container in some payment modules

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_emailalerts</name>
 	<displayName><![CDATA[Mail alerts]]></displayName>
-	<version><![CDATA[2.3.0]]></version>
+	<version><![CDATA[2.3.2]]></version>
 	<description><![CDATA[Sends e-mail notifications to customers and merchants regarding stock and order modifications.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[administration]]></tab>

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -61,7 +61,7 @@ class Ps_EmailAlerts extends Module
     {
         $this->name = 'ps_emailalerts';
         $this->tab = 'administration';
-        $this->version = '2.3.1';
+        $this->version = '2.3.2';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 
@@ -292,12 +292,17 @@ class Ps_EmailAlerts extends Module
      *
      * @param Context $context
      *
-     * @return \PrestaShop\PrestaShop\Core\Localization\Locale
+     * @return \PrestaShop\PrestaShop\Core\Localization\Locale|null
      *
      * @throws Exception
      */
     public static function getContextLocale(Context $context)
     {
+        $locale = $context->getCurrentLocale();
+        if (null !== $locale) {
+            return $locale;
+        }
+
         $containerFinder = new \PrestaShop\PrestaShop\Adapter\ContainerFinder($context);
         $container = $containerFinder->getContainer();
         if (null === $context->container) {

--- a/tests/php/phpstan/phpstan.neon
+++ b/tests/php/phpstan/phpstan.neon
@@ -11,3 +11,4 @@ parameters:
   reportUnmatchedIgnoredErrors: false
   level: 5
   ignoreErrors:
+    - '#Unreachable statement \- code above always terminates\.#'


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | In some cases, Symfony container wasn't properly initialized in the front office
| Type?         | critical
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | n/a
| How to test?  | The instruction is below

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->

1. Make sure you have `ps_emailalerts` installed
2. Install the module from the attachment
3. Visit the configuration of the `testcontainer` module before, and after this PR

[testcontainer.zip](https://github.com/PrestaShop/ps_emailalerts/files/7973636/testcontainer.zip)

The origin of the error is that they're loading `init.php` file in their module on the top of the file, this is causing some misbehavior while loading the container. This check that has been added right now should be in the module since the beginning.

