### PR TITLE
Fixed the hook listener for the hook actionProductAttributeDelete & Removed hooks actionProductOutOfStock & registerGDPRConsent as hook listeners are not defined

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,7 +2,7 @@
 <module>
 	<name>ps_emailalerts</name>
 	<displayName><![CDATA[Mail alerts]]></displayName>
-	<version><![CDATA[2.3.2]]></version>
+	<version><![CDATA[2.3.3]]></version>
 	<description><![CDATA[Sends e-mail notifications to customers and merchants regarding stock and order modifications.]]></description>
 	<author><![CDATA[PrestaShop]]></author>
 	<tab><![CDATA[administration]]></tab>

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -61,7 +61,7 @@ class Ps_EmailAlerts extends Module
     {
         $this->name = 'ps_emailalerts';
         $this->tab = 'administration';
-        $this->version = '2.3.2';
+        $this->version = '2.3.3';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 
@@ -106,10 +106,8 @@ class Ps_EmailAlerts extends Module
             !$this->registerHook('actionProductAttributeDelete') ||
             !$this->registerHook('actionProductAttributeUpdate') ||
             !$this->registerHook('actionProductCoverage') ||
-            !$this->registerHook('actionProductOutOfStock') ||
             !$this->registerHook('actionOrderReturn') ||
             !$this->registerHook('actionOrderEdited') ||
-            !$this->registerHook('registerGDPRConsent') ||
             !$this->registerHook('actionDeleteGDPRCustomer') ||
             !$this->registerHook('actionExportGDPRData') ||
             !$this->registerHook('displayProductAdditionalInfo') ||
@@ -697,7 +695,7 @@ class Ps_EmailAlerts extends Module
         Db::getInstance()->execute($sql);
     }
 
-    public function hookActionAttributeDelete($params)
+    public function hookActionProductAttributeDelete($params)
     {
         if ($params['deleteAllAttributes']) {
             $sql = '

--- a/upgrade/upgrade-2.3.3.php
+++ b/upgrade/upgrade-2.3.3.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * 2007-2021 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_3_3($object)
+{
+    return $object->unregisterHook('registerGDPRConsent')
+        && $object->unregisterHook('actionProductOutOfStock');
+}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixed the hook listener for the hook actionProductAttributeDelete<br>Removed hooks actionProductOutOfStock & registerGDPRConsent as hook listeners are not defined
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Relative to PrestaShop/Prestashop#19230
| How to test?  | Install this branch<br><br>`ps_emailalerts` is not linked to hooks `actionProductOutOfStock` & `registerGDPRConsent`<br>In upgrade, hooks `actionProductOutOfStock` & `registerGDPRConsent` are unlinked.<br><br>When the hook `actionProductAttributeDelete` is triggered, the line is now correctly removed in the table `mailalert_customer_oos`

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
