### PR TITLE
Remove class unused in classic theme, but breaking comp with BS4

### DIFF
--- a/views/templates/hook/product.tpl
+++ b/views/templates/hook/product.tpl
@@ -32,7 +32,7 @@
             {capture name='gdprContent'}{hook h='displayGDPRConsent' id_module=$id_module}{/capture}
             {if $smarty.capture.gdprContent != ''}
                <div class="gdpr_consent_wrapper mt-1">{$smarty.capture.gdprContent nofilter}</div>
-            {/if}       
+            {/if}
         {/if}
         <button
             data-product="{$product.id_product}"
@@ -41,6 +41,6 @@
             rel="nofollow">
             {l s='Notify me when available' d='Modules.Emailalerts.Shop'}
         </button>
-        <div class="js-mailalert-alerts d-none"></div>
+        <div class="js-mailalert-alerts"></div>
     </div>
 </div>


### PR DESCRIPTION
… bootstrap newer than 4 alpha 4.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Removing a CSS-class, that is useless in classic theme, but creates a compatibility issue with themes based on Bootstrap newer than 4 beta 4. See https://github.com/PrestaShop/PrestaShop/issues/28216#issuecomment-1094772517
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28216
| How to test?  | As a customer subscribe to a product notification using `classic` theme, and using a them based on a newer bootstrap (e.g. `classic-rocket`).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
