### PR TITLE
Display an info alert if the customer has already subscribed.

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -565,7 +565,7 @@ class Ps_EmailAlerts extends Module
         if ((int) $context->customer->id <= 0) {
             $this->context->smarty->assign('email', 1);
         } elseif (MailAlert::customerHasNotification($id_customer, $id_product, $id_product_attribute, (int) $context->shop->id)) {
-            return;
+            $this->context->smarty->assign('has_notification', 1);
         }
         $this->context->smarty->assign(
             [

--- a/views/templates/hook/product.tpl
+++ b/views/templates/hook/product.tpl
@@ -25,6 +25,7 @@
 
 <div class="tabs">
     <div class="js-mailalert text-center" data-url="{url entity='module' name='ps_emailalerts' controller='actions' params=['process' => 'add']}">
+    {if empty($has_notification)}
         {if !empty($email)}
             <input class="form-control" type="email" placeholder="{l s='your@email.com' d='Modules.Emailalerts.Shop'}"/>
         {/if}
@@ -42,5 +43,8 @@
             {l s='Notify me when available' d='Modules.Emailalerts.Shop'}
         </button>
         <div class="js-mailalert-alerts"></div>
+    {else}
+        <article class="mt-1 alert alert-info" role="alert">{l s='You will be notified when available' d='Modules.Emailalerts.Shop'}</article>
+    {/if}
     </div>
 </div>


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Display an info alert if the customer has already subscribed to the product notifications.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#28218.
| How to test?  | As a customer subscribe to a product notification. Display the product page again. There is an info alert.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
