### PR TITLE
Rename incorrect translation domains.

### DIFF
--- a/controllers/front/actions.php
+++ b/controllers/front/actions.php
@@ -100,7 +100,7 @@ class Ps_EmailAlertsActionsModuleFrontController extends ModuleFrontController
             exit(json_encode(
                 [
                     'error' => true,
-                    'message' => $this->trans('Your e-mail address is invalid', [], 'Modules.Mailalerts.Shop'),
+                    'message' => $this->trans('Your e-mail address is invalid', [], 'Modules.Emailalerts.Shop'),
                 ]
             ));
         }
@@ -117,14 +117,14 @@ class Ps_EmailAlertsActionsModuleFrontController extends ModuleFrontController
             exit(json_encode(
                 [
                     'error' => true,
-                    'message' => $this->trans('You already have an alert for this product', [], 'Modules.Mailalerts.Shop'),
+                    'message' => $this->trans('You already have an alert for this product', [], 'Modules.Emailalerts.Shop'),
                 ]
             ));
         } elseif (!Validate::isLoadedObject($product)) {
             exit(json_encode(
                 [
                     'error' => true,
-                    'message' => $this->trans('Your e-mail address is invalid', [], 'Modules.Mailalerts.Shop'),
+                    'message' => $this->trans('Your e-mail address is invalid', [], 'Modules.Emailalerts.Shop'),
                 ]
             ));
         }
@@ -142,7 +142,7 @@ class Ps_EmailAlertsActionsModuleFrontController extends ModuleFrontController
             exit(json_encode(
                 [
                     'error' => false,
-                    'message' => $this->trans('Request notification registered', [], 'Modules.Mailalerts.Shop'),
+                    'message' => $this->trans('Request notification registered', [], 'Modules.Emailalerts.Shop'),
                 ]
             ));
         }
@@ -150,7 +150,7 @@ class Ps_EmailAlertsActionsModuleFrontController extends ModuleFrontController
         exit(json_encode(
             [
                 'error' => true,
-                'message' => $this->trans('Your e-mail address is invalid', [], 'Modules.Mailalerts.Shop'),
+                'message' => $this->trans('Your e-mail address is invalid', [], 'Modules.Emailalerts.Shop'),
             ]
         ));
     }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This replaces the old translations domains of `Modules.Mailalerts` with the current ones `Modules.Emailalerts`
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/PrestaShop#17810
| How to test?  | Inspect the code. As the wrong translations domains do not cause a bug in FO, there is not a specific test.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
