### PR TITLE
BCC emails management

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -1352,8 +1352,9 @@ class Ps_EmailAlerts extends Module
             $mails = explode(self::__MA_MAIL_DELIMITER__, Configuration::get('MA_BCC_EMAILS'));
             if (is_array($mails)) {
                 foreach ($mails as $m) {
-                    if (!Validate::isEmail($m))
+                    if (!Validate::isEmail($m)) {
                         return;
+                    }
                 }
                 $params['bcc'] = array_merge($bcc_arr, $mails);
             }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This change allows the merchant to set one or more emails that will be set as a Blind Carbon Copy in all emails sent by the shop. This allows the merchant to keep a copy and view all the emails that the shop sends. It is often requested by merchants to keep track of mails sent, check for errors or give better customer support.
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/29130
| How to test?  | Set one or more bcc recipients in the relative field of module configuration page than make prestashop send a mail (ex change order status, make an order, ecc). A mail in Bcc will be sent to recipient set in module configuration. NOTE: this not add bcc recipient to the test email sent by "BO->Advanced Parameter->email->send test email" button, because that form do not use the Mail::Send function.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
