### PR TITLE
We must not switch context (shop and language)

### DIFF
--- a/MailAlert.php
+++ b/MailAlert.php
@@ -166,7 +166,7 @@ class MailAlert extends ObjectModel
         $link = new Link();
         $id_product = (int) $id_product;
         $id_product_attribute = (int) $id_product_attribute;
-        $customers = self::getCustomers($id_product, $id_product_attribute);
+        $customers = self::getCustomers($id_product, $id_product_attribute, Context::getContext()->shop->id);
 
         foreach ($customers as $customer) {
             $id_shop = (int) $customer['id_shop'];
@@ -297,13 +297,17 @@ class MailAlert extends ObjectModel
 
     /*
      * Get customers waiting for alert on the specified product/product attribute
+     * in shop `$id_shop` and if the shop group shares the stock in all shops of the shop group
      */
-    public static function getCustomers($id_product, $id_product_attribute)
+    public static function getCustomers($id_product, $id_product_attribute, $id_shop)
     {
         $sql = '
-			SELECT id_customer, customer_email, id_shop, id_lang
-			FROM `' . _DB_PREFIX_ . self::$definition['table'] . '`
-			WHERE `id_product` = ' . (int) $id_product . ' AND `id_product_attribute` = ' . (int) $id_product_attribute;
+			SELECT mc.id_customer, mc.customer_email, mc.id_shop, mc.id_lang
+			FROM `' . _DB_PREFIX_ . self::$definition['table'] . '` mc
+			INNER JOIN `' . _DB_PREFIX_ . 'shop` s on s.id_shop = mc.id_shop
+			INNER JOIN `' . _DB_PREFIX_ . 'shop_group` sg on s.id_shop_group = sg.id_shop_group and (s.id_shop = ' . (int) $id_shop . ' or sg.share_stock = 1)
+			INNER JOIN `' . _DB_PREFIX_ . 'shop` s2 on s2.id_shop = mc.id_shop and s2.id_shop = ' . (int) $id_shop . '
+			WHERE mc.`id_product` = ' . (int) $id_product . ' AND mc.`id_product_attribute` = ' . (int) $id_product_attribute;
 
         return Db::getInstance((bool) _PS_USE_SQL_SLAVE_)->executeS($sql);
     }

--- a/MailAlert.php
+++ b/MailAlert.php
@@ -164,13 +164,16 @@ class MailAlert extends ObjectModel
     public static function sendCustomerAlert($id_product, $id_product_attribute)
     {
         $link = new Link();
+        $context = Context::getContext();
         $id_product = (int) $id_product;
         $id_product_attribute = (int) $id_product_attribute;
-        $customers = self::getCustomers($id_product, $id_product_attribute, Context::getContext()->shop->id);
+        $current_shop = $context->shop->id;
+        $customers = self::getCustomers($id_product, $id_product_attribute, $current_shop);
 
         foreach ($customers as $customer) {
             $id_shop = (int) $customer['id_shop'];
             $id_lang = (int) $customer['id_lang'];
+            $context->shop->id = $id_shop;
 
             $product = new Product($id_product, false, $id_lang, $id_shop);
             $product_name = Product::getProductName($product->id, $id_product_attribute, $id_lang);
@@ -246,6 +249,7 @@ class MailAlert extends ObjectModel
                 $id_shop
             );
         }
+        $context->shop->id = $current_shop;
     }
 
     /*

--- a/MailAlert.php
+++ b/MailAlert.php
@@ -164,7 +164,6 @@ class MailAlert extends ObjectModel
     public static function sendCustomerAlert($id_product, $id_product_attribute)
     {
         $link = new Link();
-        $context = Context::getContext()->cloneContext();
         $id_product = (int) $id_product;
         $id_product_attribute = (int) $id_product_attribute;
         $customers = self::getCustomers($id_product, $id_product_attribute);
@@ -172,8 +171,6 @@ class MailAlert extends ObjectModel
         foreach ($customers as $customer) {
             $id_shop = (int) $customer['id_shop'];
             $id_lang = (int) $customer['id_lang'];
-            $context->shop->id = $id_shop;
-            $context->language->id = $id_lang;
 
             $product = new Product($id_product, false, $id_lang, $id_shop);
             $product_name = Product::getProductName($product->id, $id_product_attribute, $id_lang);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Sending of notification could accidentally switch shop and language context. This is fixed now. We also send only notifications in shops that share the stock. It would be useless to trigger hookActionUpdateQuantity in shops that do not share stock.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30187
| How to test?  | See [#30187](https://github.com/PrestaShop/PrestaShop/issues/30187) for the steps to reproduce the issue. After this PR, there is no longer any confusion of shops or languages.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
