### PR TITLE
Fix compatibility with psgdpr and ps >=1.7.8

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -63,7 +63,7 @@ class Ps_EmailAlerts extends Module
     {
         $this->name = 'ps_emailalerts';
         $this->tab = 'administration';
-        $this->version = '2.4.0';
+        $this->version = '2.4.1';
         $this->author = 'PrestaShop';
         $this->need_instance = 0;
 
@@ -111,6 +111,7 @@ class Ps_EmailAlerts extends Module
             !$this->registerHook('actionProductCoverage') ||
             !$this->registerHook('actionOrderReturn') ||
             !$this->registerHook('actionOrderEdited') ||
+            !$this->registerHook('registerGDPRConsent') ||
             !$this->registerHook('actionDeleteGDPRCustomer') ||
             !$this->registerHook('actionExportGDPRData') ||
             !$this->registerHook('displayProductAdditionalInfo') ||
@@ -1321,6 +1322,19 @@ class Ps_EmailAlerts extends Module
             'MA_RETURN_SLIP' => Tools::getValue('MA_RETURN_SLIP', Configuration::get('MA_RETURN_SLIP')),
             'MA_RETURN_SLIP_EMAILS' => Tools::getValue('MA_RETURN_SLIP_EMAILS', Configuration::get('MA_RETURN_SLIP_EMAILS')),
         ];
+    }
+
+    /**
+     * empty listener for registerGDPRConsent hook
+     */
+    public function hookRegisterGDPRConsent()
+    {
+        /*
+         * registerGDPRConsent is a special kind of hook that doesn't need a listener, see :
+         * https://build.prestashop.com/howtos/module/how-to-make-your-module-compliant-with-prestashop-official-gdpr-compliance-module/
+         * However since Prestashop 1.7.8, modules must implement a listener for all the hooks they register:
+         * a check is made at module installation.
+        */
     }
 
     public function isUsingNewTranslationSystem()

--- a/upgrade/upgrade-2.4.1.php
+++ b/upgrade/upgrade-2.4.1.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * 2007-2021 PrestaShop.
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License 3.0 (AFL-3.0)
+ * that is bundled with this package in the file LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/AFL-3.0
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@prestashop.com so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
+ * versions in the future. If you wish to customize PrestaShop for your
+ * needs please refer to http://www.prestashop.com for more information.
+ *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2020 PrestaShop SA
+ * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
+ * International Registered Trademark & Property of PrestaShop SA
+ */
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+function upgrade_module_2_4_1($object)
+{
+    return $object->registerHook('registerGDPRConsent');
+}

--- a/upgrade/upgrade-2.4.1.php
+++ b/upgrade/upgrade-2.4.1.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * 2007-2021 PrestaShop.
+ * 2007-2022 PrestaShop.
  *
  * NOTICE OF LICENSE
  *
@@ -19,7 +19,7 @@
  * needs please refer to http://www.prestashop.com for more information.
  *
  * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2020 PrestaShop SA
+ * @copyright 2007-2022 PrestaShop SA
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Since PrestaShop 1.7.8 seems to be required to implement the hook `registerGDPRConsent` hook and an empty listener `HookRegisterGDPRConsent`, otherwise the module is not psgdpr module compliant. This PR fix the compatibility of ps_emailalerts.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/Prestashop#30379
| How to test?  | Fresh install of latest PS 1.7.8 or PS 8.0 or PS 8.1, the module is not showed in the psgdpr module, and the gdpr checkbox are not displayed in the product page. This PR fix it. Follow PrestaShop/Prestashop#30379 for more details

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
