### PR TITLE
Fix add action customer id

### DIFF
--- a/controllers/front/actions.php
+++ b/controllers/front/actions.php
@@ -89,7 +89,7 @@ class Ps_EmailAlertsActionsModuleFrontController extends ModuleFrontController
         } elseif (Validate::isEmail((string) Tools::getValue('customer_email'))) {
             $customer_email = (string) Tools::getValue('customer_email');
             $customer = $context->customer->getByEmail($customer_email);
-            $id_customer = (isset($customer->id) && ($customer->id != null)) ? (int) $customer->id : null;
+            $id_customer = (isset($customer->id) && ($customer->id != null)) ? (int) $customer->id : 0;
         } else {
             exit(json_encode(
                 [


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | When a user isn't logged in and typed an unknown email address, we can't add this email address to database with this error `Customer id can't be empty`.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/32037
| How to test?  | See https://github.com/PrestaShop/PrestaShop/issues/32037

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
