### PR TITLE
Avoid 4 lines of --- when customization

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -430,14 +430,13 @@ class Ps_EmailAlerts extends Module
                         foreach ($customization[Product::CUSTOMIZE_TEXTFIELD] as $text) {
                             $customization_text .= $text['name'] . ': ' . $text['value'] . '<br />';
                         }
-			$customization_text .= '---<br />';
+                        $customization_text .= '---<br />';
                     }
 
                     if (isset($customization[Product::CUSTOMIZE_FILE])) {
                         $customization_text .= count($customization[Product::CUSTOMIZE_FILE]) . ' ' . $this->trans('image(s)', [], 'Modules.Emailalerts.Admin') . '<br />';
-			$customization_text .= '---<br />';
+                        $customization_text .= '---<br />';
                     }
-
                 }
                 if (method_exists('Tools', 'rtrimString')) {
                     $customization_text = Tools::rtrimString($customization_text, '---<br />');

--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -430,13 +430,14 @@ class Ps_EmailAlerts extends Module
                         foreach ($customization[Product::CUSTOMIZE_TEXTFIELD] as $text) {
                             $customization_text .= $text['name'] . ': ' . $text['value'] . '<br />';
                         }
+			$customization_text .= '---<br />';
                     }
 
                     if (isset($customization[Product::CUSTOMIZE_FILE])) {
                         $customization_text .= count($customization[Product::CUSTOMIZE_FILE]) . ' ' . $this->trans('image(s)', [], 'Modules.Emailalerts.Admin') . '<br />';
+			$customization_text .= '---<br />';
                     }
 
-                    $customization_text .= '---<br />';
                 }
                 if (method_exists('Tools', 'rtrimString')) {
                     $customization_text = Tools::rtrimString($customization_text, '---<br />');


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Avoid 4 lines of --- when customization
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | 
| How to test?  | Place an order with a product with customization, check alert email received for the new order and there aren't 4 lines of --- at the end of each product with customization 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
