### PR TITLE
Removed unused stylesheet that doesn't exists anymore

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -855,10 +855,6 @@ class Ps_EmailAlerts extends Module
             'mailalerts-js',
             'modules/' . $this->name . '/js/mailalerts.js'
         );
-        $this->context->controller->registerStylesheet(
-            'mailalerts-css',
-            'modules/' . $this->name . '/css/mailalerts.css'
-        );
     }
 
     public function hookActionAdminControllerSetMedia()


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | This PR will remove a file that is included by registerStylesheet that doesn't exists anymore. It's a refuse.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
