### PR TITLE
document on ready - deprecated

### DIFF
--- a/js/mailalerts.js
+++ b/js/mailalerts.js
@@ -41,7 +41,7 @@ function  addNotification(productId, productAttributeId) {
   return false;
 }
 
-$(document).on('ready', function() {
+$(document).ready(function() {
   const mailAlertSubmitButtonClass = '.js-mailalert-add';
   const mailAlertWrapper = $('.js-mailalert');
   const mailAlertSubmitButton = mailAlertWrapper.find(mailAlertSubmitButtonClass);


### PR DESCRIPTION
$(document).on( "ready", handler ), deprecated as of jQuery 1.8 and removed in jQuery 3.0.

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Type?         |  improvement 
| Deprecations? | yes 

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
