### PR TITLE
Remove the “>” selector to make the selector more flexible

### DIFF
--- a/js/mailalerts.js
+++ b/js/mailalerts.js
@@ -28,7 +28,7 @@ function  addNotification(productId, productAttributeId) {
   $.ajax({
     type: 'POST',
     url: $('div.js-mailalert').data('url'),
-    data: 'id_product='+productId+'&id_product_attribute='+productAttributeId+'&customer_email='+$('div.js-mailalert > input[type=email]').val(),
+    data: 'id_product='+productId+'&id_product_attribute='+productAttributeId+'&customer_email='+$('div.js-mailalert input[type=email]').val(),
     success: function (resp) {
       resp = JSON.parse(resp);
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | The “>” selector makes it impossible to customize this module, particularly as we can't add any other HTML element between the “.js-mailalert” div and the input[type=email]. </br>By removing this selector, we can add HTML elements between them and maintain the current functionality.
| Type?         |improvement
| BC breaks?    |no
| Deprecations? |no
| Fixed ticket? | /
| How to test?  |Remove the “>” selector in the file and test operation
