### PR TITLE
Fix JS bug in submit: incorrect variable caused missing variant selection

### DIFF
--- a/js/mailalerts.js
+++ b/js/mailalerts.js
@@ -22,7 +22,7 @@ function  addNotification(productId, productAttributeId) {
   if (typeof productId === 'undefined') {
     var ids = $('div.js-mailalert > input[type=hidden]');
     productId = ids.eq(0).val();
-    productIdAttribute = ids.eq(1).val();
+    productAttributeId = ids.eq(1).val();
   }
 
   $.ajax({


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fixes a JavaScript bug where an incorrect variable name caused the product reminder submission to ignore the selected product variant. This resulted in reminders being sent without specifying which combination (e.g., size/color) the user wanted to be notified about. The issue occurs on the product page when combinations are available.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | not sure.
| How to test?  | On a product with combinations, go to the front office and try to subscribe for an out-of-stock variant. Before the fix, the reminder would be submitted without specifying the variant. After the fix, the correct variant should be included in the submission and the reminder handled accordingly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
