### PR TITLE
Fix product coverage e-mail being send to wrong recipient

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -827,7 +827,7 @@ class Ps_EmailAlerts extends Module
             if (file_exists(dirname(__FILE__) . '/mails/' . $iso . '/productcoverage.txt')
                 && file_exists(dirname(__FILE__) . '/mails/' . $iso . '/productcoverage.html')) {
                 // Send 1 email by merchant mail, because Mail::Send doesn't work with an array of recipients
-                $merchant_oos_emails = explode(self::__MA_MAIL_DELIMITER__, $this->merchant_oos);
+                $merchant_oos_emails = explode(self::__MA_MAIL_DELIMITER__, $this->merchant_oos_emails);
                 foreach ($merchant_oos_emails as $merchant_mail) {
                     Mail::send(
                         $id_lang,


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Misused $this->merchant_oos_emails variable was preventing the correct recipient(s) from receiving the product out-of-stock notification email. The email was sent to the shop admin instead of the address(es) configured in the module.
| Type?         | bug fix 
| BC breaks?    |  no
| Deprecations? |  no
| Fixed ticket? |  n/a
| How to test?  | Configure one or more email addresses in the Email alerts module (section Out of stock > Send to).  Trigger an out-of-stock event (e.g. by reducing product quantity below the threshold).  Before applying this patch, notice that the email is sent to the shop admin instead of the configured address(es).  After applying this patch, the notification should be correctly sent to the configured recipient(s).

