### PR TITLE
Use isMainAccount to generate unique account link IDs

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -792,7 +792,13 @@ class Ps_EmailAlerts extends Module
 
     public function hookDisplayCustomerAccount($params)
     {
-        return $this->customer_qty ? $this->display(__FILE__, 'my-account.tpl') : null;
+        if ($this->customer_qty) {
+          $this->context->smarty->assign('isMainAccount', $params['isMainAccount'] ?? false);
+
+          return $this->display(__FILE__, 'my-account.tpl');
+        }
+
+        return null;
     }
 
     public function hookDisplayMyAccountBlock($params)


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |This PR updates ps_emailalerts to read the isMainAccount context passed through displayCustomerAccount and use it in the Hummingbird account link template. This allows the module to generate distinct link IDs for the sidebar and the main account page, avoiding duplicate HTML IDs.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | https://github.com/PrestaShop/hummingbird/issues/1032
| How to test?  | 
| Related PR | https://github.com/PrestaShop/hummingbird/pull/1033

### Notes
This PR is the companion change to the related Hummingbird PR. Hummingbird now passes `isMainAccount `to the `displayCustomerAccount` hook, and this module uses that context to generate unique IDs for account links in each rendering location.
This PR updates `ps_emailalerts` only.
The same fix pattern can also be applied to other Hummingbird module templates using `displayCustomerAccount` with static IDs, such as:
- `blockwishlist`
- `psgdpr`
<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
