### PR TITLE
Use real stock for the back-in-stock notification prompt

### DIFF
--- a/ps_emailalerts.php
+++ b/ps_emailalerts.php
@@ -662,7 +662,17 @@ class Ps_EmailAlerts extends Module
 
     public function hookDisplayProductAdditionalInfo($params)
     {
-        if ($params['product']['minimal_quantity'] <= $params['product']['quantity']
+        // Use the real available stock, not $params['product']['quantity'], which is reduced by
+        // the quantity the current customer already has in their cart. Otherwise a customer who
+        // put the whole stock in their cart would see (and could register) a back-in-stock
+        // notification for a product that is actually still in stock.
+        $realQuantity = StockAvailable::getQuantityAvailableByProduct(
+            (int) $params['product']['id'],
+            (int) $params['product']['id_product_attribute'],
+            (int) $this->context->shop->id
+        );
+
+        if ($params['product']['minimal_quantity'] <= $realQuantity
             || !$this->customer_qty
             || !Configuration::get('PS_STOCK_MANAGEMENT')
             || Product::isAvailableWhenOutOfStock($params['product']['out_of_stock'])) {


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | `hookDisplayProductAdditionalInfo()` decided whether to offer the "notify me when back in stock" prompt using `$params['product']['quantity']`. On the product page that value is the stock **minus the quantity the current customer already has in their own cart**, so a customer who put the whole stock of an in-stock product into their cart saw `quantity = 0`, was offered the prompt, registered a notification, and later received a back-in-stock email for a product that never actually went out of stock. The fix reads the real available stock with `StockAvailable::getQuantityAvailableByProduct()` (which is independent of any cart) so the prompt is only shown when the product is genuinely out of stock.
| Type?         | bug fix
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes PrestaShop/ps_emailalerts#153.
| How to test?  | Enable the "out of stock" customer notification in the module settings. Create a product with 3 in stock and "deny orders when out of stock". As a customer, add all 3 to your cart and reload the product page: before, the back-in-stock prompt appears (and you can register for it); after, it no longer appears because the product is still in stock. A genuinely out-of-stock product (real stock 0) still shows the prompt. Verified against the database: for an in-stock product with the whole stock in the cart the prompt is no longer rendered, while a product whose real stock is 0 still renders it.
| Sponsor company   |
